### PR TITLE
Inner Ref Error

### DIFF
--- a/src/date/DateInput.tsx
+++ b/src/date/DateInput.tsx
@@ -199,7 +199,7 @@ class DateInput extends React.Component<
         <div className={`${prefixCls}-date-input-wrap`}>
           <InputMask
             mask={this.props.format === 'MM/DD/YYYY' ? '99/99/9999' : undefined}
-            innerRef={this.saveDateInput}
+            inputRef={this.saveDateInput}
             className={`${prefixCls}-input ${invalidClass}`}
             value={str}
             disabled={props.disabled}


### PR DESCRIPTION
We have a console error about inner ref on dom element.  it looks like input mask does take inputRef as a prop so trying that instead.

![image](https://user-images.githubusercontent.com/31905923/86250607-c7c3e900-bb7e-11ea-8a5f-38f63b86cef3.png)
